### PR TITLE
Add hex alpha channel support and require Node.js 6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+yarn.lock

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 sudo: false
 language: node_js
 node_js:
-  - 'iojs'
-  - '0.12'
-  - '0.10'
+  - '8'
+  - '6'

--- a/index.js
+++ b/index.js
@@ -30,6 +30,5 @@ module.exports = function (hex) {
 	}
 
 	const num = parseInt(hex, 16);
-	// eslint-disable-next-line no-mixed-operators
-	return [num >> 16, num >> 8 & 255, num & 255, alpha];
+	return [num >> 16, (num >> 8) & 255, num & 255, alpha];
 };

--- a/index.js
+++ b/index.js
@@ -1,16 +1,36 @@
 'use strict';
 module.exports = function (hex) {
-	if (typeof hex !== 'string') {
-		throw new TypeError('Expected a string');
+	if (
+		typeof hex !== 'string' ||
+		/[^#a-f0-9]/gi.test(hex) ||
+		!/^#?[a-f0-9]{3}[a-f0-9]?$|^#?[a-f0-9]{6}([a-f0-9]{2})?$/i.test(hex)
+	) {
+		throw new TypeError('Expected a valid hex string');
 	}
 
 	hex = hex.replace(/^#/, '');
+	let alpha = 255;
+
+	if (hex.length === 8) {
+		alpha = parseInt(hex.substring(6, 8), 16);
+		hex = hex.substring(0, 6);
+	}
+
+	if (hex.length === 4) {
+		alpha = parseInt(hex.substring(3, 4).repeat(2), 16);
+		hex = hex.substring(0, 3);
+	}
 
 	if (hex.length === 3) {
 		hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
 	}
 
-	var num = parseInt(hex, 16);
+	const num = parseInt(hex, 16);
+	// eslint-disable-next-line no-mixed-operators
+	const result = [num >> 16, num >> 8 & 255, num & 255];
+	if (alpha !== 255) {
+		result.push(alpha);
+	}
 
-	return [num >> 16, num >> 8 & 255, num & 255];
+	return result;
 };

--- a/index.js
+++ b/index.js
@@ -1,10 +1,14 @@
 'use strict';
+
+const hexChars = 'a-f\\d';
+const match3or4Hex = `#?[${hexChars}]{3}[${hexChars}]?`;
+const match6or8Hex = `#?[${hexChars}]{6}([${hexChars}]{2})?`;
+
+const nonHexChars = new RegExp(`[^#${hexChars}]`, 'gi');
+const validHexSize = new RegExp(`^${match3or4Hex}$|^${match6or8Hex}$`, 'i');
+
 module.exports = function (hex) {
-	if (
-		typeof hex !== 'string' ||
-		/[^#a-f0-9]/gi.test(hex) ||
-		!/^#?[a-f0-9]{3}[a-f0-9]?$|^#?[a-f0-9]{6}([a-f0-9]{2})?$/i.test(hex)
-	) {
+	if (typeof hex !== 'string' || nonHexChars.test(hex) || !validHexSize.test(hex)) {
 		throw new TypeError('Expected a valid hex string');
 	}
 
@@ -12,12 +16,12 @@ module.exports = function (hex) {
 	let alpha = 255;
 
 	if (hex.length === 8) {
-		alpha = parseInt(hex.substring(6, 8), 16);
+		alpha = parseInt(hex.slice(6, 8), 16);
 		hex = hex.substring(0, 6);
 	}
 
 	if (hex.length === 4) {
-		alpha = parseInt(hex.substring(3, 4).repeat(2), 16);
+		alpha = parseInt(hex.slice(3, 4).repeat(2), 16);
 		hex = hex.substring(0, 3);
 	}
 

--- a/index.js
+++ b/index.js
@@ -31,10 +31,5 @@ module.exports = function (hex) {
 
 	const num = parseInt(hex, 16);
 	// eslint-disable-next-line no-mixed-operators
-	const result = [num >> 16, num >> 8 & 255, num & 255];
-	if (alpha !== 255) {
-		result.push(alpha);
-	}
-
-	return result;
+	return [num >> 16, num >> 8 & 255, num & 255, alpha];
 };

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
     "url": "http://sindresorhus.com"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=6"
   },
   "scripts": {
-    "test": "node test.js"
+    "test": "xo && ava"
   },
   "files": [
     "index.js"
@@ -28,6 +28,7 @@
     "converter"
   ],
   "devDependencies": {
-    "ava": "0.0.3"
+    "ava": "*",
+    "xo": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hex-rgb",
   "version": "1.0.0",
-  "description": "Convert HEX color to RGB",
+  "description": "Convert HEX color to RGB(A)",
   "license": "MIT",
   "repository": "sindresorhus/hex-rgb",
   "author": {
@@ -21,6 +21,7 @@
   "keywords": [
     "hex",
     "rgb",
+    "rgba",
     "color",
     "colour",
     "convert",

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # hex-rgb [![Build Status](https://travis-ci.org/sindresorhus/hex-rgb.svg?branch=master)](https://travis-ci.org/sindresorhus/hex-rgb)
 
-> Convert HEX color to RGB
+> Convert HEX color to RGB(A)
 
 
 ## Install
@@ -23,6 +23,12 @@ hexRgb('#4183c4');
 
 hexRgb('#fff');
 //=> [255, 255, 255]
+
+hexRgb('#4183c488');
+//=> [65, 131, 196, 136]
+
+hexRgb('#0008');
+//=> [0, 0, 0, 136]
 ```
 
 

--- a/test.js
+++ b/test.js
@@ -19,14 +19,14 @@ test('rejects', t => {
 });
 
 test('hex', t => {
-	t.is(hexRgb('4183c4').join(','), '65,131,196');
-	t.is(hexRgb('#4183c4').join(','), '65,131,196');
-	t.is(hexRgb('#000').join(','), '0,0,0');
+	t.deepEqual(hexRgb('4183c4'), [65, 131, 196]);
+	t.deepEqual(hexRgb('#4183c4'), [65, 131, 196]);
+	t.deepEqual(hexRgb('#000'), [0, 0, 0]);
 });
 
 test('hex with alpha', t => {
-	t.is(hexRgb('4183c488').join(','), '65,131,196,136');
-	t.is(hexRgb('#4183c488').join(','), '65,131,196,136');
-	t.is(hexRgb('#0008').join(','), '0,0,0,136');
-	t.is(hexRgb('#000f').join(','), '0,0,0');
+	t.deepEqual(hexRgb('4183c488'), [65, 131, 196, 136]);
+	t.deepEqual(hexRgb('#4183c488'), [65, 131, 196, 136]);
+	t.deepEqual(hexRgb('#0008'), [0, 0, 0, 136]);
+	t.deepEqual(hexRgb('#000f'), [0, 0, 0]);
 });

--- a/test.js
+++ b/test.js
@@ -19,14 +19,14 @@ test('rejects', t => {
 });
 
 test('hex', t => {
-	t.deepEqual(hexRgb('4183c4'), [65, 131, 196]);
-	t.deepEqual(hexRgb('#4183c4'), [65, 131, 196]);
-	t.deepEqual(hexRgb('#000'), [0, 0, 0]);
+	t.deepEqual(hexRgb('4183c4'), [65, 131, 196, 255]);
+	t.deepEqual(hexRgb('#4183c4'), [65, 131, 196, 255]);
+	t.deepEqual(hexRgb('#000'), [0, 0, 0, 255]);
 });
 
 test('hex with alpha', t => {
 	t.deepEqual(hexRgb('4183c488'), [65, 131, 196, 136]);
 	t.deepEqual(hexRgb('#4183c488'), [65, 131, 196, 136]);
 	t.deepEqual(hexRgb('#0008'), [0, 0, 0, 136]);
-	t.deepEqual(hexRgb('#000f'), [0, 0, 0]);
+	t.deepEqual(hexRgb('#000f'), [0, 0, 0, 255]);
 });

--- a/test.js
+++ b/test.js
@@ -1,24 +1,32 @@
 'use strict';
-var test = require('ava');
-var hexRgb = require('./');
+import test from 'ava';
+import hexRgb from './';
 
-test('hex', function (t) {
-	var rgb = hexRgb('4183c4');
-	t.assert(rgb[0] === 65);
-	t.assert(rgb[1] === 131);
-	t.assert(rgb[2] === 196);
+const reject = (t, string) => {
+	return t.throws(() => {
+		hexRgb(string);
+	}, TypeError).message;
+};
+
+test('rejects', t => {
+	const message = 'Expected a valid hex string';
+	t.is(reject(t, 123), message);
+	t.is(reject(t, '🦄'), message);
+	t.is(reject(t, '#12🦄'), message);
+	t.is(reject(t, '#12345'), message);
+	t.is(reject(t, '#1234567'), message);
+	t.is(reject(t, '#123456789'), message);
 });
 
-test('strip leading #', function (t) {
-	var rgb = hexRgb('#4183c4');
-	t.assert(rgb[0] === 65);
-	t.assert(rgb[1] === 131);
-	t.assert(rgb[2] === 196);
+test('hex', t => {
+	t.is(hexRgb('4183c4').join(','), '65,131,196');
+	t.is(hexRgb('#4183c4').join(','), '65,131,196');
+	t.is(hexRgb('#000').join(','), '0,0,0');
 });
 
-test('shorthand', function (t) {
-	var rgb = hexRgb('#000');
-	t.assert(rgb[0] === 0);
-	t.assert(rgb[1] === 0);
-	t.assert(rgb[2] === 0);
+test('hex with alpha', t => {
+	t.is(hexRgb('4183c488').join(','), '65,131,196,136');
+	t.is(hexRgb('#4183c488').join(','), '65,131,196,136');
+	t.is(hexRgb('#0008').join(','), '0,0,0,136');
+	t.is(hexRgb('#000f').join(','), '0,0,0');
 });


### PR DESCRIPTION
* Added `xo`.
* Updated `ava`.
* Updated node version.
* Add support for 4 and 8 digit hex values.
* Added tests

```js
hexRgb('#4183c488');
//=> [65, 131, 196, 136]

hexRgb('#0008');
//=> [0, 0, 0, 136]
```

---

I would also like to add support to output the RGB value in an object. For example:

```js
hexRgb('#4183c488', {output: 'object'});
//=> {R: 65, G: 131, B: 196, A: 136}
```

This should be added in a new PR, but I wanted to get your thoughts on it.