### PR TITLE
Add `format` option and change the default output to an object

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const match6or8Hex = `#?[${hexChars}]{6}([${hexChars}]{2})?`;
 const nonHexChars = new RegExp(`[^#${hexChars}]`, 'gi');
 const validHexSize = new RegExp(`^${match3or4Hex}$|^${match6or8Hex}$`, 'i');
 
-module.exports = function (hex) {
+module.exports = function (hex, options = {}) {
 	if (typeof hex !== 'string' || nonHexChars.test(hex) || !validHexSize.test(hex)) {
 		throw new TypeError('Expected a valid hex string');
 	}
@@ -30,5 +30,11 @@ module.exports = function (hex) {
 	}
 
 	const num = parseInt(hex, 16);
-	return [num >> 16, (num >> 8) & 255, num & 255, alpha];
+	const red = num >> 16;
+	const green = (num >> 8) & 255;
+	const blue = num & 255;
+
+	return options.format === 'array' ?
+		[red, green, blue, alpha] :
+		{red, green, blue, alpha};
 };

--- a/readme.md
+++ b/readme.md
@@ -16,19 +16,22 @@ $ npm install --save hex-rgb
 var hexRgb = require('hex-rgb');
 
 hexRgb('4183c4');
-//=> [65, 131, 196]
+//=> {red: 65, green: 131, blue: 196, alpha: 255}
 
 hexRgb('#4183c4');
-//=> [65, 131, 196]
+//=> {red: 65, green: 131, blue: 196, alpha: 255}
 
 hexRgb('#fff');
-//=> [255, 255, 255]
+//=> {red: 255, green: 255, blue: 255, alpha: 255}
 
 hexRgb('#4183c488');
-//=> [65, 131, 196, 136]
+//=> {red: 65, green: 131, blue: 196, alpha: 136}
 
 hexRgb('#0008');
-//=> [0, 0, 0, 136]
+//=> {red: 0, green: 0, blue: 0, alpha: 136}
+
+hexRgb('#4183c488', {format: 'array'});
+//=> [65, 131, 196, 136]
 ```
 
 

--- a/test.js
+++ b/test.js
@@ -18,15 +18,24 @@ test('rejects', t => {
 	t.is(reject(t, '#123456789'), message);
 });
 
-test('hex', t => {
-	t.deepEqual(hexRgb('4183c4'), [65, 131, 196, 255]);
-	t.deepEqual(hexRgb('#4183c4'), [65, 131, 196, 255]);
-	t.deepEqual(hexRgb('#000'), [0, 0, 0, 255]);
+test('hex; output object', t => {
+	const options = {format: 'object'};
+	t.deepEqual(hexRgb('#4183c4', options), {red: 65, green: 131, blue: 196, alpha: 255});
+	t.deepEqual(hexRgb('#000', options), {red: 0, green: 0, blue: 0, alpha: 255});
+	t.deepEqual(hexRgb('#0008', options), {red: 0, green: 0, blue: 0, alpha: 136});
+	t.deepEqual(hexRgb('4183c488', options), {red: 65, green: 131, blue: 196, alpha: 136});
+	t.deepEqual(hexRgb('#4183c488'), {red: 65, green: 131, blue: 196, alpha: 136});
+	t.deepEqual(hexRgb('4183c4'), {red: 65, green: 131, blue: 196, alpha: 255});
+	t.deepEqual(hexRgb('#000f'), {red: 0, green: 0, blue: 0, alpha: 255});
 });
 
-test('hex with alpha', t => {
-	t.deepEqual(hexRgb('4183c488'), [65, 131, 196, 136]);
-	t.deepEqual(hexRgb('#4183c488'), [65, 131, 196, 136]);
-	t.deepEqual(hexRgb('#0008'), [0, 0, 0, 136]);
-	t.deepEqual(hexRgb('#000f'), [0, 0, 0, 255]);
+test('hex; output array', t => {
+	const options = {format: 'array'};
+	t.deepEqual(hexRgb('4183c4', options), [65, 131, 196, 255]);
+	t.deepEqual(hexRgb('#4183c4', options), [65, 131, 196, 255]);
+	t.deepEqual(hexRgb('#000', options), [0, 0, 0, 255]);
+	t.deepEqual(hexRgb('4183c488', options), [65, 131, 196, 136]);
+	t.deepEqual(hexRgb('#4183c488', options), [65, 131, 196, 136]);
+	t.deepEqual(hexRgb('#0008', options), [0, 0, 0, 136]);
+	t.deepEqual(hexRgb('#000f', options), [0, 0, 0, 255]);
 });


### PR DESCRIPTION
Add a format option with a default `format` value set to `'object'`:

```js
hexRgb('#4183c4', {format: 'object'});
//=> {red: 65, green: 131, blue: 196, alpha: 255}

hexRgb('#4183c488', {format: 'array'});
//=> [65, 131, 196, 136]
```

This PR is based on #1, so it needs to be merged first.
