### PR TITLE
Add Babel & create dist package that can support ES5

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": [["@babel/preset-env"]],
+  "plugins": []
+}

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,43 @@
+'use strict';
+
+var hexChars = 'a-f\\d';
+var match3or4Hex = "#?[".concat(hexChars, "]{3}[").concat(hexChars, "]?");
+var match6or8Hex = "#?[".concat(hexChars, "]{6}([").concat(hexChars, "]{2})?");
+var nonHexChars = new RegExp("[^#".concat(hexChars, "]"), 'gi');
+var validHexSize = new RegExp("^".concat(match3or4Hex, "$|^").concat(match6or8Hex, "$"), 'i');
+
+module.exports = function (hex) {
+  var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+  if (typeof hex !== 'string' || nonHexChars.test(hex) || !validHexSize.test(hex)) {
+    throw new TypeError('Expected a valid hex string');
+  }
+
+  hex = hex.replace(/^#/, '');
+  var alpha = 255;
+
+  if (hex.length === 8) {
+    alpha = parseInt(hex.slice(6, 8), 16) / 255;
+    hex = hex.substring(0, 6);
+  }
+
+  if (hex.length === 4) {
+    alpha = parseInt(hex.slice(3, 4).repeat(2), 16) / 255;
+    hex = hex.substring(0, 3);
+  }
+
+  if (hex.length === 3) {
+    hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
+  }
+
+  var num = parseInt(hex, 16);
+  var red = num >> 16;
+  var green = num >> 8 & 255;
+  var blue = num & 255;
+  return options.format === 'array' ? [red, green, blue, alpha] : {
+    red: red,
+    green: green,
+    blue: blue,
+    alpha: alpha
+  };
+};

--- a/package.json
+++ b/package.json
@@ -1,35 +1,46 @@
 {
-	"name": "hex-rgb",
-	"version": "3.0.0",
-	"description": "Convert HEX color to RGBA",
-	"license": "MIT",
-	"repository": "sindresorhus/hex-rgb",
-	"author": {
-		"name": "Sindre Sorhus",
-		"email": "sindresorhus@gmail.com",
-		"url": "sindresorhus.com"
-	},
-	"engines": {
-		"node": ">=6"
-	},
-	"scripts": {
-		"test": "xo && ava"
-	},
-	"files": [
-		"index.js"
-	],
-	"keywords": [
-		"hex",
-		"rgb",
-		"rgba",
-		"color",
-		"colour",
-		"convert",
-		"conversion",
-		"converter"
-	],
-	"devDependencies": {
-		"ava": "*",
-		"xo": "*"
-	}
+  "name": "hex-rgb",
+  "version": "3.0.0",
+  "description": "Convert HEX color to RGBA",
+  "license": "MIT",
+  "repository": "sindresorhus/hex-rgb",
+  "author": {
+    "name": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com"
+  },
+  "engines": {
+    "node": ">=6"
+  },
+  "browserslist": [
+    "last 1 version",
+    "> 1%",
+    "maintained node versions",
+    "not dead"
+  ],
+  "scripts": {
+    "test": "xo && ava",
+    "build": "babel index.js --out-dir dist"
+  },
+  "files": [
+    "index.js"
+  ],
+  "main": "dist/index.js",
+  "keywords": [
+    "hex",
+    "rgb",
+    "rgba",
+    "color",
+    "colour",
+    "convert",
+    "conversion",
+    "converter"
+  ],
+  "devDependencies": {
+    "@babel/cli": "^7.1.2",
+    "@babel/core": "^7.1.2",
+    "@babel/preset-env": "^7.1.0",
+    "ava": "*",
+    "xo": "*"
+  }
 }


### PR DESCRIPTION
Some projects would not compile with ES6-specific code like `const` keyword. I've added a distribution folder with a transpiled bundle via Babel env.