### PR TITLE
Fix `package.json` export error

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
 		"url": "https://sindresorhus.com"
 	},
 	"type": "module",
-	"exports": "./index.js",
+	"exports": {
+		".": "./index.js",
+		"./package.json": "./package.json"
+	},
 	"engines": {
 		"node": ">=12"
 	},


### PR DESCRIPTION
This fixes the error

> Package subpath './package.json' is not defined by "exports"

by specifying the path to `package.json`.

See https://github.com/react-native-community/cli/issues/1168.